### PR TITLE
Add image tagging

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,9 @@
 name: Build images
 on: push
 
+env:
+  TAG_NAME: 2.7.2-alpine
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,16 +23,28 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{ secrets.PACKAGES_TOKEN }}
+
           docker tag builder docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:latest
+          docker tag builder docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:${{ TAG_NAME }}
           docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:latest
+          docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:${{ TAG_NAME }}
+
           docker tag final docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:latest
           docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:latest
+          docker tag final docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:${{ TAG_NAME }}
+          docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:${{ TAG_NAME }}
 
       - name: Push the images to Docker Hub
         if: github.ref == 'refs/heads/master'
         run: |
           docker login -u ledermann -p ${{ secrets.DOCKER_TOKEN }}
+
           docker tag builder ledermann/rails-base-builder:latest
           docker push ledermann/rails-base-builder:latest
+          docker tag builder ledermann/rails-base-builder:${{ TAG_NAME }}
+          docker push ledermann/rails-base-builder:${{ TAG_NAME }}
+
           docker tag final ledermann/rails-base-final:latest
           docker push ledermann/rails-base-final:latest
+          docker tag final ledermann/rails-base-final:${{ TAG_NAME }}
+          docker push ledermann/rails-base-final:${{ TAG_NAME }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,14 +25,14 @@ jobs:
           docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{ secrets.PACKAGES_TOKEN }}
 
           docker tag builder docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:latest
-          docker tag builder docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:${{ TAG_NAME }}
+          docker tag builder docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:${{ env.TAG_NAME }}
           docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:latest
-          docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:${{ TAG_NAME }}
+          docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-builder:${{ env.TAG_NAME }}
 
           docker tag final docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:latest
           docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:latest
-          docker tag final docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:${{ TAG_NAME }}
-          docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:${{ TAG_NAME }}
+          docker tag final docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:${{ env.TAG_NAME }}
+          docker push docker.pkg.github.com/ledermann/docker-rails-base/rails-base-final:${{ env.TAG_NAME }}
 
       - name: Push the images to Docker Hub
         if: github.ref == 'refs/heads/master'
@@ -41,10 +41,10 @@ jobs:
 
           docker tag builder ledermann/rails-base-builder:latest
           docker push ledermann/rails-base-builder:latest
-          docker tag builder ledermann/rails-base-builder:${{ TAG_NAME }}
-          docker push ledermann/rails-base-builder:${{ TAG_NAME }}
+          docker tag builder ledermann/rails-base-builder:${{ env.TAG_NAME }}
+          docker push ledermann/rails-base-builder:${{ env.TAG_NAME }}
 
           docker tag final ledermann/rails-base-final:latest
           docker push ledermann/rails-base-final:latest
-          docker tag final ledermann/rails-base-final:${{ TAG_NAME }}
-          docker push ledermann/rails-base-final:${{ TAG_NAME }}
+          docker tag final ledermann/rails-base-final:${{ env.TAG_NAME }}
+          docker push ledermann/rails-base-final:${{ env.TAG_NAME }}

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Using [Dependabot](https://dependabot.com/), every updated Ruby gem or Node modu
 #### Build Docker image
 
 ```Dockerfile
-FROM ledermann/rails-base-builder:latest AS Builder
-FROM ledermann/rails-base-final:latest
+FROM ledermann/rails-base-builder:2.7.2-alpine AS Builder
+FROM ledermann/rails-base-final:2.7.2-alpine
 USER app
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 ```


### PR DESCRIPTION
Currently, updating the version of Ruby (as was the case with [Ruby 2.7.2](7cf868d647c73de1d3c444c41c01f5d207ac8fa8)) requires a **simultaneous** update of the applications that depend on this repo. Otherwise, the build process fails - see #439.

This PR fixes this by adding another tag with the Ruby version number of the base image, e.g. `2.7.2-alpine`.

After this PR is merged, it's recommended to use this tag in the application's Dockerfile. Later, when Ruby 2.7.3 arrives, building the application's image will not break, because there is still an image with `2.7.2-alpine` (but not updated anymore).

What do you think, @deepakinseattle?