### PR TITLE
Add ability to use private NPM packages

### DIFF
--- a/Builder/Dockerfile
+++ b/Builder/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.0-experimental
 FROM ruby:3.0.0-alpine
 LABEL maintainer="georg@ledermann.dev"
 

--- a/Builder/Dockerfile
+++ b/Builder/Dockerfile
@@ -48,7 +48,7 @@ ONBUILD COPY . /app
 #      we hide the credentials while compiling assets (by renaming them before and after)
 #
 ONBUILD RUN mv config/credentials.yml.enc config/credentials.yml.enc.bak 2>/dev/null || true
-ONBUILD RUN RAILS_ENV=production \
+ONBUILD RUN --mount=type=secret,id=npmrc,dst=/root/.npmrc RAILS_ENV=production \
             SECRET_KEY_BASE=dummy \
             RAILS_MASTER_KEY=dummy \
             bundle exec rails assets:precompile


### PR DESCRIPTION
Added the ability to install private NPM packages in your package.json.

Steps to get it working:
- Add this workaround: https://github.com/ledermann/docker-rails-base/issues/545#issuecomment-788761621 to your Dockerfile
-  Build your docker image with the following command:
   ```sh
   DOCKER_BUILDKIT=1 docker build --secret id=npmrc,src=$HOME/.npmrc .
   ``` 
