### PR TITLE
Upgrade Ruby to 3.0.3

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: Build images
 on: push
 
 env:
-  TAG_NAME: 3.0.2-alpine
+  TAG_NAME: 3.0.3-alpine
   USER_NAME: ledermann
 
 jobs:

--- a/Builder/Dockerfile
+++ b/Builder/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-FROM ruby:3.0.2-alpine
+FROM ruby:3.0.3-alpine
 LABEL maintainer="georg@ledermann.dev"
 
 # Add basic packages

--- a/Builder/Gemfile
+++ b/Builder/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.2'
+ruby '3.0.3'
 
 # Full-stack web application framework. (https://rubyonrails.org)
 gem 'rails', '~> 6.1.4'

--- a/Builder/Gemfile.lock
+++ b/Builder/Gemfile.lock
@@ -358,7 +358,7 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 RUBY VERSION
-   ruby 3.0.2p107
+   ruby 3.0.3p157
 
 BUNDLED WITH
-   2.2.22
+   2.2.32

--- a/Final/Dockerfile
+++ b/Final/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.2-alpine
+FROM ruby:3.0.3-alpine
 LABEL maintainer="georg@ledermann.dev"
 
 # Add basic packages

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Note: Before I started timing, the base image was not available on my machine, s
 This repo is based on the following assumptions:
 
 - Your Docker host is compatible with [Alpine Linux 3.14](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0), which requires Docker 20.10.0 or later
-- Your app is compatible with [Ruby 3.0.2 for Alpine Linux](https://github.com/docker-library/ruby/blob/master/3.0/alpine3.14/Dockerfile)
+- Your app is compatible with [Ruby 3.0.3 for Alpine Linux](https://github.com/docker-library/ruby/blob/master/3.0/alpine3.14/Dockerfile)
 - Your app uses Ruby on Rails 6.0 or 6.1
 - Your app uses PostgreSQL
 - Your app installs Node modules with [Yarn](https://yarnpkg.com/)
@@ -48,7 +48,7 @@ It uses [multi-stage building](https://docs.docker.com/develop/develop-images/mu
 
 The `Builder` stage installs Ruby gems and Node modules. It also includes Git, Node.js and some build tools - all we need to compile assets.
 
-- Based on [ruby:3.0.2-alpine](https://github.com/docker-library/ruby/blob/master/3.0/alpine3.14/Dockerfile)
+- Based on [ruby:3.0.3-alpine](https://github.com/docker-library/ruby/blob/master/3.0/alpine3.14/Dockerfile)
 - Adds packages needed for installing gems and compiling assets: Git, Node.js, Yarn, PostgreSQL client and build tools
 - Adds some standard Ruby gems (Rails 6.1 etc., see [Gemfile](./Builder/Gemfile))
 - Adds Node modules from the Rails community (Turbo, Stimulus etc., see [package.json](./Builder/package.json))
@@ -61,7 +61,7 @@ See [Builder/Dockerfile](./Builder/Dockerfile)
 
 The `Final` stage builds the production image, which includes just the bare minimum.
 
-- Based on [ruby:3.0.2-alpine](https://github.com/docker-library/ruby/blob/master/3.0/alpine3.14/Dockerfile)
+- Based on [ruby:3.0.3-alpine](https://github.com/docker-library/ruby/blob/master/3.0/alpine3.14/Dockerfile)
 - Adds packages needed for production: postgresql-client, tzdata, file
 - Via ONBUILD triggers it mainly copies the app and gems from the `Builder` stage
 
@@ -80,8 +80,8 @@ Using [Dependabot](https://dependabot.com/), every updated Ruby gem or Node modu
 Add this `Dockerfile` to your application:
 
 ```Dockerfile
-FROM ledermann/rails-base-builder:3.0.2-alpine AS Builder
-FROM ledermann/rails-base-final:3.0.2-alpine
+FROM ledermann/rails-base-builder:3.0.3-alpine AS Builder
+FROM ledermann/rails-base-final:3.0.3-alpine
 USER app
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 ```
@@ -99,8 +99,8 @@ $ docker build .
 [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) requires a little [workaround](https://github.com/moby/buildkit/issues/816) to trigger the ONBUILD statements. Add a `COPY` statement to the `Dockerfile`:
 
 ```Dockerfile
-FROM ledermann/rails-base-builder:3.0.2-alpine AS Builder
-FROM ledermann/rails-base-final:3.0.2-alpine
+FROM ledermann/rails-base-builder:3.0.3-alpine AS Builder
+FROM ledermann/rails-base-final:3.0.3-alpine
 
 # Workaround to trigger Builder's ONBUILDs to finish:
 COPY --from=Builder /etc/alpine-release /tmp/dummy
@@ -176,6 +176,7 @@ When a new Ruby version comes out, a new tag is introduced and the images will b
 
 | Ruby version | Tag          | First published |
 |--------------|--------------|-----------------|
+| 3.0.3        | 3.0.3-alpine | 2021-11-24      |
 | 3.0.2        | 3.0.2-alpine | 2021-07-08      |
 | 3.0.1        | 3.0.1-alpine | 2021-04-06      |
 | 3.0.0        | 3.0.0-alpine | 2021-02-15      |


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2021/11/24/ruby-3-0-3-released/

@ledermann I used your [3.0.2 upgrade](https://github.com/ledermann/docker-rails-base/commit/f6895d592b29a7410ce8aaea67b628229f6afb6a) as a guide for what needed to be updated.

Thanks for maintaining this base image! 